### PR TITLE
fix: handle SSL validation and correct office service URL testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ These variables affect the runtime behavior of the Docker container:
 - `SVC_HOST`: Hostname or IP address where the censhare service client connects. This setting is crucial for network communication setup.
 - `SVC_INSTANCES`: Defines the number of instances for parallel processing within the service client. Default is `4`.
 - `OFFICE_URL`: URL of the office service for document conversion services. If not set or the service is unreachable, the related functionality is disabled.
+- `OFFICE_VALIDATE_CERTS`: If the OFFICE_URL uses SSL, the certificates are validated. To turn validation off, set the `OFFICE_VALIDATE_CERTS` to `false`.
 - `REPO_USER`, `REPO_PASS`, and `VERSION`: These can also be provided at runtime to download and configure the censhare-Service-Client if not done at build time.
 
 ## Customization


### PR DESCRIPTION
- Added `str_to_bool` function to convert `OFFICE_VALIDATE_CERTS` environment variable to a boolean.
- Updated `handle_office_facility` to handle SSL certificate validation using `urllib3`.
- Configured `handle_office_facility` to send data as `multipart/form-data` for correct office service URL testing.
- Modified `update_facility_paths` to use the new `OFFICE_VALIDATE_CERTS` environment variable.
- Updated README.md to document the `OFFICE_VALIDATE_CERTS` environment variable.
- Adjusted unit tests to mock `urllib3.PoolManager.request` and include the testing of sending file content.

This fixes the issue where the office service URL validation would fail when using SSL without cert validation and ensures correct interaction with the Collabora service.