### PR TITLE
Feature/direct_assets_access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,8 @@ on:
     types: [published]
 
 jobs:
-  build-and-test:
+  build-and-test-amd64:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
 
     steps:
     - name: Checkout repository
@@ -43,20 +40,61 @@ jobs:
         username: ahuservices
         password: ${{ secrets.DOCKER_TOKEN }}
 
-    - name: Build Docker image for testing
-      id: build_image
+    - name: Build Docker image for testing (amd64)
+      id: build_image_amd64
       run: |
         docker buildx create --use --name mybuilder
         docker buildx inspect mybuilder --bootstrap
-        docker buildx build --target test --platform linux/${{ matrix.arch }} --tag cs-image-tools:${{ github.sha }}-${{ matrix.arch }} --output type=docker .
+        docker buildx build --target test --platform linux/amd64 --tag cs-image-tools:${{ github.sha }}-amd64 --output type=docker .
 
-    - name: Run tests
+    - name: Run tests (amd64)
       run: |
-        docker run --rm cs-image-tools:${{ github.sha }}-${{ matrix.arch }}
+        docker run --rm cs-image-tools:${{ github.sha }}-amd64
+
+  build-and-test-arm64:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        buildkitd-flags: --debug
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ahuservices
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Build Docker image for testing (arm64)
+      id: build_image_arm64
+      run: |
+        docker buildx create --use --name mybuilder
+        docker buildx inspect mybuilder --bootstrap
+        docker buildx build --target test --platform linux/arm64 --tag cs-image-tools:${{ github.sha }}-arm64 --output type=docker .
+
+    - name: Run tests (arm64)
+      run: |
+        docker run --rm cs-image-tools:${{ github.sha }}-arm64
 
   multi-arch-build-and-push:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test-amd64, build-and-test-arm64]
     if: github.event_name == 'release'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ docker run -d --name csclient1 \
   cs-image-tools:v1.0
 ```
 
+### Volume Configuration with VOLUMES_INFO
+
+To dynamically configure volume information, use the VOLUMES_INFO environment variable to provide a JSON string with volume details. This will completely replace the existing volumes section in the hosts.xml file.
+
+#### Example VOLUMES_INFO
+
+```yaml
+VOLUMES_INFO: >
+  {
+    "assets": {"physicalurl": "file:///opt/corpus/work/assets/", "filestreaming": true},
+    "assets-temp": {"physicalurl": "file:///opt/corpus/work/assets-temp/", "filestreaming": true},
+    "assets-s3": {"endpoint": "s3.amazon.com", "bucket-name": "assets-s3", "secret": "foobar"},
+    "temp": {"physicalurl": "file:///opt/corpus/work/temp/", "filestreaming": false}
+  }
+```
+
+#### Docker Run Command with VOLUMES_INFO
+
+```bash
+docker run -d --name csclient1 \
+  -e REPO_USER=repo_user -e REPO_PASS=repo_password -e VERSION=2023.1.1 \
+  -e SVC_USER=user -e SVC_PASS=password -e SVC_HOST=host.example.com \
+  -e VOLUMES_INFO='{"assets": {"physicalurl": "file:///assets/", "filestreaming": false}, "assets-temp": {"physicalurl": "file:///assets/assets-temp/", "filestreaming": false}, "assets-s3": {"endpoint": "s3.amazon.com", "bucket-name": "assets-s3", "secret": "foobar"}, "temp": {"physicalurl": "file:///opt/corpus/work/temp/", "filestreaming": true}}' \
+  -v /opt/corpus/work/assets:/assets
+  cs-image-tools:v1.0
+```
+
 ## Running the Container together with collabora office to create previews for office documents
 
 To use a service for creating Office document previews, here is an example docker-compose:
@@ -127,6 +154,7 @@ These variables affect the runtime behavior of the Docker container:
 - `SVC_INSTANCES`: Defines the number of instances for parallel processing within the service client. Default is `4`.
 - `OFFICE_URL`: URL of the office service for document conversion services. If not set or the service is unreachable, the related functionality is disabled.
 - `OFFICE_VALIDATE_CERTS`: If the OFFICE_URL uses SSL, the certificates are validated. To turn validation off, set the `OFFICE_VALIDATE_CERTS` to `false`.
+- `VOLUMES_INFO`: A JSON string defining the volume configurations, including physicalurl and filestreaming status for each volume.
 - `REPO_USER`, `REPO_PASS`, and `VERSION`: These can also be provided at runtime to download and configure the censhare-Service-Client if not done at build time.
 
 ## Customization


### PR DESCRIPTION
- Skip arm64 builds during pull requests to reduce build time.
- Include both amd64 and arm64 architectures for release builds.
- Test both architectures up to the test stage during releases.
- Merge layers for both architectures and push to Docker Hub after successful tests.
- Update GitHub Actions workflow to conditionally include arm64 builds only for releases.