### PR TITLE
feat(docker): update and extend build with new libraries and updated versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ Before you begin, ensure you have Docker installed on your system. You can downl
 
 ## Tools included in the image
 
-|Tool         |Version |
-|-------------|--------|
-|ImageMagick  |7.1.1-41|
-|Ghostscript  |10.04.0 |
-|ExifTool     |13.00   |
-|FFmpeg       |7.1     |
-|pngquant     |2.18.0  |
-|wkhtmltoimage|0.12.6  |
+|Tool         |Version    |
+|-------------|-----------|
+|ImageMagick  |7.1.1-47   |
+|Ghostscript  |10.05.0    |
+|ExifTool     |13.25      |
+|FFmpeg       |7.1.1      |
+|pngquant     |2.18.0     |
+|wkhtmltoimage|0.12.6.1-2 |
 
 ImageMagick Features and Delegates:
 
 ```
 Features: Cipher DPC HDRI Modules OpenMP(4.5)
-Delegates (built-in): bzlib cairo djvu fftw fontconfig freetype gvc heic jbig jng jp2 jpeg lcms ltdl lzma openexr pangocairo png raqm raw rsvg tiff webp wmf xml zip zlib zstd
+Delegates (built-in): bzlib cairo djvu fftw fontconfig fpx freetype gvc heic jbig jng jp2 jpeg jxl lcms ltdl lzma openexr pangocairo png raqm raw rsvg tiff uhdr webp wmf xml zip zlib zstd
 ```
 
 ## Building the Docker Image

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -23,7 +23,7 @@ def test_user_corpus_can_execute_commands():
 
 def test_ghostscript_installed_and_version():
     """Test that Ghostscript is installed, executable, and the version is correct."""
-    expected_version = '10.04.0'
+    expected_version = '10.05.0'
     try:
         # Check if 'gs' command is available and get version
         result = subprocess.run(['/usr/local/bin/gs', '-version'], capture_output=True, text=True, check=True)
@@ -43,9 +43,10 @@ def test_ghostscript_installed_and_version():
 
 def test_imagemagick_installed_and_version():
     """Test that ImageMagick is installed, executable, and the version is correct."""
-    expected_version = '7.1.1-41'
+    expected_version = '7.1.1-47'
     expected_features = 'Features: Cipher DPC HDRI Modules OpenMP(4.5)'
-    expected_delegagtes = 'Delegates (built-in): bzlib cairo djvu fftw fontconfig freetype gvc heic jbig jng jp2 jpeg lcms ltdl lzma openexr pangocairo png raqm raw rsvg tiff webp wmf xml zip zlib zstd'
+    expected_delegagtes = 'Delegates (built-in): bzlib cairo djvu fftw fontconfig fpx freetype gvc heic jbig jng jp2 jpeg jxl lcms ltdl lzma openexr pangocairo png raqm raw rsvg tiff uhdr webp wmf xml zip zlib zstd'
+
     try:
         # Check if 'magick' command is available and get version
         result = subprocess.run(['/usr/local/bin/magick', '-version'], capture_output=True, text=True, check=True)
@@ -67,7 +68,7 @@ def test_imagemagick_installed_and_version():
 
 def test_exiftool_installed_and_version():
     """Test that ExifTool is installed, executable, and the version is correct."""
-    expected_version = '13.00'
+    expected_version = '13.25'
     try:
         # Check if 'exiftool' command is available and get version
         result = subprocess.run(['/usr/local/bin/exiftool', '-ver'], capture_output=True, text=True, check=True)
@@ -87,7 +88,7 @@ def test_exiftool_installed_and_version():
 
 def test_ffmpeg_installed_and_version():
     """Test that ffmpeg is installed, executable, and the version is correct."""
-    expected_version = '7.1'
+    expected_version = '7.1.1'
     try:
         # Check if 'ffmpeg' command is available and get version
         result = subprocess.run(['/usr/local/bin/ffmpeg', '-version'], capture_output=True, text=True, check=True)


### PR DESCRIPTION
feat(docker): update and extend build with new libraries and updated versions

- Update ImageMagick to 7.1.1-47, Ghostscript to 10.05.0, ExifTool to 13.25, and FFmpeg to 7.1.1
- Add support for libjxl, libfpx, and libultrahdr (UHDR)
- Enhance ImageMagick build with FPX, JXL, UHDR, HEIC, and security policy
- Improve wkhtmltopdf installation to handle libssl1.1 compatibility on amd64/arm64
- Update README to reflect new tool versions and delegates
- Adjust test suite to match updated versions and delegates