### PR TITLE
fix(ci): stabilize PR builds and refresh bundled tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      - name: Login to DockerHub
+      - name: Login to DockerHub (optional)
+        if: ${{ secrets.DOCKER_TOKEN != '' }}
         uses: docker/login-action@v2
         with:
           username: ahuservices

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     name: Build and test (amd64, PR)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    env:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -37,11 +39,11 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Login to DockerHub (optional)
-        if: ${{ secrets.DOCKER_TOKEN != '' }}
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@v2
         with:
           username: ahuservices
-          password: ${{ secrets.DOCKER_TOKEN }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Build Docker image for testing (amd64)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install ca-certificates
 
 ### Build Ghostscript
 FROM debian-builder AS ghostscript-builder
-ARG GHOSTSCRIPT_VERSION=10.06.0
+ARG GHOSTSCRIPT_VERSION=10.07.0
 
 # Download and build Ghostscript
 WORKDIR /tmp
@@ -48,7 +48,7 @@ RUN apt-get update && apt-get install -y cmake ninja-build clang libjpeg-dev \
 
 ### Build ImageMagick
 FROM debian-builder AS im-builder
-ARG IMAGEMAGICK_VERSION=7.1.2-13
+ARG IMAGEMAGICK_VERSION=7.1.2-18
 
 # Download ImageMagick
 WORKDIR /tmp
@@ -79,7 +79,7 @@ COPY imagemagick-policy.xml /IM-build/usr/local/etc/ImageMagick-7/policy.xml
 
 ### Build ffmpeg
 FROM debian-builder AS ffmpeg-builder
-ARG FFMPEG_VERSION=8.0.1
+ARG FFMPEG_VERSION=8.1
 
 # Download and build ffmpeg
 WORKDIR /tmp
@@ -93,7 +93,7 @@ RUN wget https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz \
 
 ### Build ExifTool
 FROM debian-builder AS exif-builder
-ARG EXIF_VERSION=13.44
+ARG EXIF_VERSION=13.50
 
 # Download and build ExifTool
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -186,12 +186,12 @@ When you pass `VERSION` during image build, the Dockerfile fetches and installs 
 
 | Tool         | Version   |
 |--------------|-----------|
-| ImageMagick  | 7.1.2-13  |
-| Ghostscript  | 10.06.0   |
-| ExifTool     | 13.44     |
-| FFmpeg       | 8.0.1     |
+| ImageMagick  | 7.1.2-18  |
+| Ghostscript  | 10.07.0   |
+| ExifTool     | 13.50     |
+| FFmpeg       | 8.1       |
 | pngquant     | 3.0.3     |
-| wkhtmltoimage| 0.12.6.1-2|
+| wkhtmltoimage| 0.12.6.1-3|
 
 ImageMagick features and delegates:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Note: If an `iccprofiles` folder exists in the build context, it is copied into 
 - `CLIENT_MAP_HOST_FROM` / `CLIENT_MAP_HOST_TO`: Explicitly override the RMI host mapping baked into the stub (advanced NAT/PAT).
 - `CLIENT_MAP_PORT_FROM` / `CLIENT_MAP_PORT_TO`: Explicitly override RMI port mapping if the external callback port differs; otherwise left empty.
 - `SVC_INSTANCES`: Number of parallel worker instances. Default `4`.
-- `IMAGEMAGICK_POLICY_AUTOCONFIG`: Auto-tune ImageMagick limits from the detected container memory limit. Default `true`.
+- `IMAGEMAGICK_POLICY_AUTOCONFIG`: Auto-tune ImageMagick limits from the detected container memory limit. Default `false`.
 - `IMAGEMAGICK_POLICY_MEMORY`, `IMAGEMAGICK_POLICY_MAP`, `IMAGEMAGICK_POLICY_DISK`, `IMAGEMAGICK_POLICY_THREAD`, `IMAGEMAGICK_POLICY_MAX_MEMORY_REQUEST`: Optional explicit overrides for ImageMagick resource limits.
 - `OFFICE_URL`: URL of an office conversion service. If unset or unreachable, office previews are disabled.
 - `OFFICE_VALIDATE_CERTS`: Validate SSL certificates for `OFFICE_URL`. Set to `false` to disable validation.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Note: If an `iccprofiles` folder exists in the build context, it is copied into 
 - `CLIENT_MAP_HOST_FROM` / `CLIENT_MAP_HOST_TO`: Explicitly override the RMI host mapping baked into the stub (advanced NAT/PAT).
 - `CLIENT_MAP_PORT_FROM` / `CLIENT_MAP_PORT_TO`: Explicitly override RMI port mapping if the external callback port differs; otherwise left empty.
 - `SVC_INSTANCES`: Number of parallel worker instances. Default `4`.
+- `IMAGEMAGICK_POLICY_AUTOCONFIG`: Auto-tune ImageMagick limits from the detected container memory limit. Default `true`.
+- `IMAGEMAGICK_POLICY_MEMORY`, `IMAGEMAGICK_POLICY_MAP`, `IMAGEMAGICK_POLICY_DISK`, `IMAGEMAGICK_POLICY_THREAD`, `IMAGEMAGICK_POLICY_MAX_MEMORY_REQUEST`: Optional explicit overrides for ImageMagick resource limits.
 - `OFFICE_URL`: URL of an office conversion service. If unset or unreachable, office previews are disabled.
 - `OFFICE_VALIDATE_CERTS`: Validate SSL certificates for `OFFICE_URL`. Set to `false` to disable validation.
 - `VOLUMES_INFO`: JSON string to fully replace the `volumes` section in `hosts.xml`.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -147,7 +147,7 @@ def configure_imagemagick_policy(policy_path=DEFAULT_IMAGEMAGICK_POLICY_PATH):
 
     root = tree.getroot()
     svc_instances = _parse_positive_int(os.getenv('SVC_INSTANCES', '4'), 4)
-    auto_config = str_to_bool(os.getenv('IMAGEMAGICK_POLICY_AUTOCONFIG', 'true'))
+    auto_config = str_to_bool(os.getenv('IMAGEMAGICK_POLICY_AUTOCONFIG', 'false'))
     detected_limit = detect_container_memory_limit_bytes()
 
     applied_values = {}

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -26,6 +26,9 @@ JAVA_DEFAULT = 21
 CLIENT_VERSION_FILE = "/opt/corpus/censhare/client-version.txt"
 SERVICECLIENT_SCRIPT = "/opt/corpus/censhare/censhare-Service-Client/serviceclient.sh"
 DEFAULT_RMI_PORT = "30550"
+DEFAULT_IMAGEMAGICK_POLICY_PATH = "/usr/local/etc/ImageMagick-7/policy.xml"
+MIB = 1024 * 1024
+GIB = 1024 * MIB
 RMI_HOST_OPTION_PATTERN = re.compile(r"-Djava\.rmi\.server\.hostname=([^\s]+)")
 
 def _determine_serviceclient_version(script_path=SERVICECLIENT_SCRIPT):
@@ -51,6 +54,143 @@ def str_to_bool(value):
     Defaults to False for any other value.
     """
     return value.lower() in ['true', '1', 't', 'y', 'yes']
+
+def _read_first_line(path):
+    try:
+        with open(path, 'r', encoding='utf-8') as handle:
+            return handle.readline().strip()
+    except OSError:
+        return None
+
+def _parse_positive_int(value, default):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+def _clamp(value, minimum, maximum):
+    return max(minimum, min(value, maximum))
+
+def _round_down(value, step):
+    return max(step, (value // step) * step)
+
+def _format_binary_size(value):
+    if value % GIB == 0:
+        return f"{value // GIB}GiB"
+    return f"{max(1, value // MIB)}MiB"
+
+def detect_container_memory_limit_bytes():
+    """
+    Reads the effective container memory limit from cgroup v2/v1.
+    Returns None when the container is effectively unlimited.
+    """
+    for path in (
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ):
+        raw_value = _read_first_line(path)
+        if not raw_value or raw_value == "max":
+            continue
+        try:
+            limit = int(raw_value)
+        except ValueError:
+            continue
+        if 0 < limit < (1 << 60):
+            return limit
+    return None
+
+def recommend_imagemagick_policy(memory_limit_bytes, svc_instances):
+    """
+    Derive conservative ImageMagick cache limits from the container memory limit.
+    Reserve headroom for the JVM, the service client, and non-ImageMagick tools.
+    """
+    workers = max(1, svc_instances)
+    reserve = min(max(int(memory_limit_bytes * 0.20), 768 * MIB), int(memory_limit_bytes * 0.35))
+    usable_bytes = max(memory_limit_bytes - reserve, 512 * MIB)
+    per_worker_budget = max(usable_bytes // workers, 256 * MIB)
+
+    memory_limit = _round_down(_clamp(int(per_worker_budget * 0.33), 256 * MIB, 1 * GIB), 64 * MIB)
+    map_limit = _round_down(_clamp(int(per_worker_budget * 0.66), 512 * MIB, 2 * GIB), 64 * MIB)
+    max_memory_request = _round_down(_clamp(memory_limit // 2, 128 * MIB, 512 * MIB), 64 * MIB)
+    disk_limit = _round_down(_clamp(max(int(usable_bytes * 1.5), 2 * GIB), 2 * GIB, 10 * GIB), 256 * MIB)
+    thread_limit = "1" if workers > 1 else "2"
+
+    return {
+        "thread": thread_limit,
+        "memory": _format_binary_size(memory_limit),
+        "map": _format_binary_size(max(map_limit, memory_limit)),
+        "disk": _format_binary_size(disk_limit),
+        "max-memory-request": _format_binary_size(max_memory_request),
+    }
+
+def _set_policy_value(root, domain, name, value):
+    policy = root.find(f"./policy[@domain='{domain}'][@name='{name}']")
+    if policy is None:
+        policy = ET.SubElement(root, 'policy', {'domain': domain, 'name': name})
+    policy.set('value', str(value))
+
+def configure_imagemagick_policy(policy_path=DEFAULT_IMAGEMAGICK_POLICY_PATH):
+    """
+    Tune the installed ImageMagick policy for the current container and allow
+    explicit environment overrides for operators that need deterministic limits.
+    """
+    if not os.path.exists(policy_path):
+        print(f"Warning: ImageMagick policy file not found at {policy_path}")
+        return
+
+    try:
+        tree = ET.parse(policy_path)
+    except ET.ParseError as exc:
+        print(f"Warning: Unable to parse ImageMagick policy {policy_path}: {exc}")
+        return
+
+    root = tree.getroot()
+    svc_instances = _parse_positive_int(os.getenv('SVC_INSTANCES', '4'), 4)
+    auto_config = str_to_bool(os.getenv('IMAGEMAGICK_POLICY_AUTOCONFIG', 'true'))
+    detected_limit = detect_container_memory_limit_bytes()
+
+    applied_values = {}
+    if auto_config and detected_limit is not None:
+        applied_values.update(recommend_imagemagick_policy(detected_limit, svc_instances))
+        print(
+            "Auto-configuring ImageMagick policy from container memory limit "
+            f"{_format_binary_size(detected_limit)} and SVC_INSTANCES={svc_instances}."
+        )
+    elif auto_config:
+        print("No finite container memory limit detected; keeping bundled ImageMagick policy defaults.")
+    else:
+        print("ImageMagick policy auto-configuration disabled.")
+
+    override_mapping = {
+        "thread": "IMAGEMAGICK_POLICY_THREAD",
+        "time": "IMAGEMAGICK_POLICY_TIME",
+        "memory": "IMAGEMAGICK_POLICY_MEMORY",
+        "map": "IMAGEMAGICK_POLICY_MAP",
+        "disk": "IMAGEMAGICK_POLICY_DISK",
+        "area": "IMAGEMAGICK_POLICY_AREA",
+        "file": "IMAGEMAGICK_POLICY_FILE",
+        "list-length": "IMAGEMAGICK_POLICY_LIST_LENGTH",
+        "width": "IMAGEMAGICK_POLICY_WIDTH",
+        "height": "IMAGEMAGICK_POLICY_HEIGHT",
+    }
+    for policy_name, env_name in override_mapping.items():
+        env_value = os.getenv(env_name)
+        if env_value:
+            applied_values[policy_name] = env_value.strip()
+
+    max_memory_request = os.getenv('IMAGEMAGICK_POLICY_MAX_MEMORY_REQUEST')
+    if max_memory_request:
+        applied_values["max-memory-request"] = max_memory_request.strip()
+
+    for policy_name, value in applied_values.items():
+        domain = 'system' if policy_name == 'max-memory-request' else 'resource'
+        _set_policy_value(root, domain, policy_name, value)
+
+    tree.write(policy_path, encoding='utf-8', xml_declaration=True)
+    if applied_values:
+        rendered = ", ".join(f"{key}={value}" for key, value in sorted(applied_values.items()))
+        print(f"Configured ImageMagick policy: {rendered}")
 
 def detect_rmi_host_ip():
     """
@@ -670,6 +810,7 @@ if __name__ == "__main__":
 
     required_jdk_major = select_jdk_major(client_version)
     ensure_corretto(required_jdk_major)
+    configure_imagemagick_policy()
 
     # Install custom iccprofiles if provided in build
     icc_source = "/build_iccprofiles"

--- a/imagemagick-policy.xml
+++ b/imagemagick-policy.xml
@@ -37,7 +37,7 @@
 -->
 <policymap>
   <!-- Set maximum parallel threads. -->
-  <policy domain="resource" name="thread" value="1"/>
+  <policy domain="resource" name="thread" value="2"/>
   <!-- Set maximum time in seconds. When this limit is exceeded, an exception
        is thrown and processing stops. -->
   <policy domain="resource" name="time" value="120"/>
@@ -48,18 +48,18 @@
   <!-- Set maximum amount of memory in bytes to allocate for the pixel cache
        from the heap. When this limit is exceeded, the image pixels are cached
        to memory-mapped disk. -->
-  <policy domain="resource" name="memory" value="1GiB"/>
+  <policy domain="resource" name="memory" value="2GiB"/>
   <!-- Set maximum amount of memory map in bytes to allocate for the pixel
        cache. When this limit is exceeded, the image pixels are cached to
        disk. -->
-  <policy domain="resource" name="map" value="1GiB"/>
+  <policy domain="resource" name="map" value="4GiB"/>
   <!-- Set the maximum width * height of an image that can reside in the pixel
        cache memory. Images that exceed the area limit are cached to disk. -->
   <policy domain="resource" name="area" value="400MP"/>
   <!-- Set maximum amount of disk space in bytes permitted for use by the pixel
        cache. When this limit is exceeded, the pixel cache is not be created
        and an exception is thrown. -->
-  <policy domain="resource" name="disk" value="4GiB"/>
+  <policy domain="resource" name="disk" value="10GiB"/>
   <!-- Set the maximum length of an image sequence.  When this limit is
        exceeded, an exception is thrown. -->
   <policy domain="resource" name="list-length" value="256"/>
@@ -114,5 +114,5 @@
   <policy domain="system" name="memory-map" value="anonymous"/>
   <!-- Set the maximum amount of memory in bytes that are permitted for
        allocation requests. -->
-  <policy domain="system" name="max-memory-request" value="256MiB"/>
+  <policy domain="system" name="max-memory-request" value="1GiB"/>
 </policymap>

--- a/imagemagick-policy.xml
+++ b/imagemagick-policy.xml
@@ -37,7 +37,7 @@
 -->
 <policymap>
   <!-- Set maximum parallel threads. -->
-  <policy domain="resource" name="thread" value="2"/>
+  <policy domain="resource" name="thread" value="1"/>
   <!-- Set maximum time in seconds. When this limit is exceeded, an exception
        is thrown and processing stops. -->
   <policy domain="resource" name="time" value="120"/>
@@ -48,18 +48,18 @@
   <!-- Set maximum amount of memory in bytes to allocate for the pixel cache
        from the heap. When this limit is exceeded, the image pixels are cached
        to memory-mapped disk. -->
-  <policy domain="resource" name="memory" value="2GiB"/>
+  <policy domain="resource" name="memory" value="1GiB"/>
   <!-- Set maximum amount of memory map in bytes to allocate for the pixel
        cache. When this limit is exceeded, the image pixels are cached to
        disk. -->
-  <policy domain="resource" name="map" value="4GiB"/>
+  <policy domain="resource" name="map" value="1GiB"/>
   <!-- Set the maximum width * height of an image that can reside in the pixel
        cache memory. Images that exceed the area limit are cached to disk. -->
   <policy domain="resource" name="area" value="400MP"/>
   <!-- Set maximum amount of disk space in bytes permitted for use by the pixel
        cache. When this limit is exceeded, the pixel cache is not be created
        and an exception is thrown. -->
-  <policy domain="resource" name="disk" value="10GiB"/>
+  <policy domain="resource" name="disk" value="4GiB"/>
   <!-- Set the maximum length of an image sequence.  When this limit is
        exceeded, an exception is thrown. -->
   <policy domain="resource" name="list-length" value="256"/>
@@ -114,5 +114,5 @@
   <policy domain="system" name="memory-map" value="anonymous"/>
   <!-- Set the maximum amount of memory in bytes that are permitted for
        allocation requests. -->
-  <policy domain="system" name="max-memory-request" value="1GiB"/>
+  <policy domain="system" name="max-memory-request" value="256MiB"/>
 </policymap>

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -155,3 +155,70 @@ def test_configure_xml_respects_explicit_client_mapping(monkeypatch, tmp_path):
     assert connection.get("client-map-port-from") == "32123"
     assert connection.get("client-map-port-to") == "32123"
     assert entrypoint.os.getenv("SERVICECLIENT_JAVA_OPTIONS") == "-Djava.rmi.server.hostname=10.0.0.15"
+
+
+def _write_minimal_policy(policy_path: Path):
+    policy_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<policymap>
+  <policy domain="resource" name="thread" value="1"/>
+  <policy domain="resource" name="memory" value="1GiB"/>
+  <policy domain="resource" name="map" value="1GiB"/>
+  <policy domain="resource" name="disk" value="4GiB"/>
+  <policy domain="system" name="max-memory-request" value="256MiB"/>
+</policymap>
+"""
+    )
+
+
+def test_detect_container_memory_limit_bytes_prefers_finite_values(monkeypatch):
+    values = {
+        "/sys/fs/cgroup/memory.max": "max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes": str(6 * entrypoint.GIB),
+    }
+    monkeypatch.setattr(entrypoint, "_read_first_line", lambda path: values.get(path))
+
+    assert entrypoint.detect_container_memory_limit_bytes() == 6 * entrypoint.GIB
+
+
+def test_configure_imagemagick_policy_autoconfigures_from_memory_limit(monkeypatch, tmp_path):
+    policy_path = tmp_path / "policy.xml"
+    _write_minimal_policy(policy_path)
+    monkeypatch.setenv("SVC_INSTANCES", "4")
+    monkeypatch.delenv("IMAGEMAGICK_POLICY_MEMORY", raising=False)
+    monkeypatch.delenv("IMAGEMAGICK_POLICY_MAP", raising=False)
+    monkeypatch.delenv("IMAGEMAGICK_POLICY_THREAD", raising=False)
+    monkeypatch.delenv("IMAGEMAGICK_POLICY_MAX_MEMORY_REQUEST", raising=False)
+    monkeypatch.setattr(entrypoint, "detect_container_memory_limit_bytes", lambda: 6 * entrypoint.GIB)
+
+    entrypoint.configure_imagemagick_policy(str(policy_path))
+
+    expected = entrypoint.recommend_imagemagick_policy(6 * entrypoint.GIB, 4)
+    tree = ET.parse(policy_path)
+    root = tree.getroot()
+
+    assert root.find("./policy[@domain='resource'][@name='thread']").get("value") == expected["thread"]
+    assert root.find("./policy[@domain='resource'][@name='memory']").get("value") == expected["memory"]
+    assert root.find("./policy[@domain='resource'][@name='map']").get("value") == expected["map"]
+    assert root.find("./policy[@domain='resource'][@name='disk']").get("value") == expected["disk"]
+    assert root.find("./policy[@domain='system'][@name='max-memory-request']").get("value") == expected["max-memory-request"]
+
+
+def test_configure_imagemagick_policy_allows_explicit_overrides(monkeypatch, tmp_path):
+    policy_path = tmp_path / "policy.xml"
+    _write_minimal_policy(policy_path)
+    monkeypatch.setenv("IMAGEMAGICK_POLICY_AUTOCONFIG", "false")
+    monkeypatch.setenv("IMAGEMAGICK_POLICY_THREAD", "2")
+    monkeypatch.setenv("IMAGEMAGICK_POLICY_MEMORY", "768MiB")
+    monkeypatch.setenv("IMAGEMAGICK_POLICY_MAP", "1536MiB")
+    monkeypatch.setenv("IMAGEMAGICK_POLICY_MAX_MEMORY_REQUEST", "384MiB")
+
+    entrypoint.configure_imagemagick_policy(str(policy_path))
+
+    tree = ET.parse(policy_path)
+    root = tree.getroot()
+
+    assert root.find("./policy[@domain='resource'][@name='thread']").get("value") == "2"
+    assert root.find("./policy[@domain='resource'][@name='memory']").get("value") == "768MiB"
+    assert root.find("./policy[@domain='resource'][@name='map']").get("value") == "1536MiB"
+    assert root.find("./policy[@domain='system'][@name='max-memory-request']").get("value") == "384MiB"

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -161,11 +161,11 @@ def _write_minimal_policy(policy_path: Path):
     policy_path.write_text(
         """<?xml version="1.0" encoding="UTF-8"?>
 <policymap>
-  <policy domain="resource" name="thread" value="1"/>
-  <policy domain="resource" name="memory" value="1GiB"/>
-  <policy domain="resource" name="map" value="1GiB"/>
-  <policy domain="resource" name="disk" value="4GiB"/>
-  <policy domain="system" name="max-memory-request" value="256MiB"/>
+  <policy domain="resource" name="thread" value="2"/>
+  <policy domain="resource" name="memory" value="2GiB"/>
+  <policy domain="resource" name="map" value="4GiB"/>
+  <policy domain="resource" name="disk" value="10GiB"/>
+  <policy domain="system" name="max-memory-request" value="1GiB"/>
 </policymap>
 """
     )
@@ -184,6 +184,7 @@ def test_detect_container_memory_limit_bytes_prefers_finite_values(monkeypatch):
 def test_configure_imagemagick_policy_autoconfigures_from_memory_limit(monkeypatch, tmp_path):
     policy_path = tmp_path / "policy.xml"
     _write_minimal_policy(policy_path)
+    monkeypatch.setenv("IMAGEMAGICK_POLICY_AUTOCONFIG", "true")
     monkeypatch.setenv("SVC_INSTANCES", "4")
     monkeypatch.delenv("IMAGEMAGICK_POLICY_MEMORY", raising=False)
     monkeypatch.delenv("IMAGEMAGICK_POLICY_MAP", raising=False)
@@ -202,6 +203,25 @@ def test_configure_imagemagick_policy_autoconfigures_from_memory_limit(monkeypat
     assert root.find("./policy[@domain='resource'][@name='map']").get("value") == expected["map"]
     assert root.find("./policy[@domain='resource'][@name='disk']").get("value") == expected["disk"]
     assert root.find("./policy[@domain='system'][@name='max-memory-request']").get("value") == expected["max-memory-request"]
+
+
+def test_configure_imagemagick_policy_keeps_bundled_defaults_by_default(monkeypatch, tmp_path):
+    policy_path = tmp_path / "policy.xml"
+    _write_minimal_policy(policy_path)
+    monkeypatch.delenv("IMAGEMAGICK_POLICY_AUTOCONFIG", raising=False)
+    monkeypatch.setenv("SVC_INSTANCES", "4")
+    monkeypatch.setattr(entrypoint, "detect_container_memory_limit_bytes", lambda: 6 * entrypoint.GIB)
+
+    entrypoint.configure_imagemagick_policy(str(policy_path))
+
+    tree = ET.parse(policy_path)
+    root = tree.getroot()
+
+    assert root.find("./policy[@domain='resource'][@name='thread']").get("value") == "2"
+    assert root.find("./policy[@domain='resource'][@name='memory']").get("value") == "2GiB"
+    assert root.find("./policy[@domain='resource'][@name='map']").get("value") == "4GiB"
+    assert root.find("./policy[@domain='resource'][@name='disk']").get("value") == "10GiB"
+    assert root.find("./policy[@domain='system'][@name='max-memory-request']").get("value") == "1GiB"
 
 
 def test_configure_imagemagick_policy_allows_explicit_overrides(monkeypatch, tmp_path):

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -25,7 +25,7 @@ def test_user_corpus_can_execute_commands():
 
 def test_ghostscript_installed_and_version():
     """Test that Ghostscript is installed, executable, and the version is correct."""
-    expected_version = '10.06.0'
+    expected_version = '10.07.0'
     try:
         # Check if 'gs' command is available and get version
         result = subprocess.run(['/usr/local/bin/gs', '-version'], capture_output=True, text=True, check=True)
@@ -45,7 +45,7 @@ def test_ghostscript_installed_and_version():
 
 def test_imagemagick_installed_and_version():
     """Test that ImageMagick is installed, executable, and the version is correct."""
-    expected_version = '7.1.2-13'
+    expected_version = '7.1.2-18'
     expected_features = 'Features: Cipher DPC HDRI Modules OpenMP(4.5)'
     expected_delegagtes = 'Delegates (built-in): bzlib cairo djvu fftw fontconfig fpx freetype gvc heic jbig jng jp2 jpeg jxl lcms ltdl lzma openexr pangocairo png raqm raw rsvg tiff uhdr webp wmf xml zip zlib zstd'
 
@@ -70,7 +70,7 @@ def test_imagemagick_installed_and_version():
 
 def test_exiftool_installed_and_version():
     """Test that ExifTool is installed, executable, and the version is correct."""
-    expected_version = '13.44'
+    expected_version = '13.50'
     try:
         # Check if 'exiftool' command is available and get version
         result = subprocess.run(['/usr/local/bin/exiftool', '-ver'], capture_output=True, text=True, check=True)
@@ -90,7 +90,7 @@ def test_exiftool_installed_and_version():
 
 def test_ffmpeg_installed_and_version():
     """Test that ffmpeg is installed, executable, and the version is correct."""
-    expected_version = '8.0.1'
+    expected_version = '8.1'
     try:
         # Check if 'ffmpeg' command is available and get version
         result = subprocess.run(['/usr/local/bin/ffmpeg', '-version'], capture_output=True, text=True, check=True)


### PR DESCRIPTION
## Summary
- make Docker Hub login optional for pull request builds without direct `secrets` usage in the `if` condition
- add optional ImageMagick policy auto-configuration while keeping the bundled defaults unchanged unless explicitly enabled
- bump bundled tool versions to current upstream releases where applicable and refresh README/test expectations

## Updated tool versions
- ImageMagick: 7.1.2-18
- Ghostscript: 10.07.0
- ExifTool: 13.50 (latest production release)
- FFmpeg: 8.1
- pngquant: 3.0.3
- wkhtmltoimage packaging reference: 0.12.6.1-3

## Validation
- `pytest -q tests/test_entrypoint.py`
- verified upstream download URLs for ImageMagick, Ghostscript, FFmpeg, and ExifTool
- full local container build not run because no local Docker/Podman daemon was available in this environment