### PR TITLE
docs(readme): add project header and support wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > Production hardening and rendering experiments for censhare image tooling in containerized Service-Client workflows.
 
+[![Docker](https://img.shields.io/badge/Container-Docker-2496ED?logo=docker&logoColor=white)](https://docs.docker.com/)
+[![Java](https://img.shields.io/badge/Java-11%2F17%2F21-007396?logo=openjdk&logoColor=white)](https://openjdk.org/)
+[![License](https://img.shields.io/github/license/ahu-services/cs-image-tools)](LICENSE)
+
 [![Support via bunq](https://img.shields.io/badge/Support-bunq-00A1E0?style=flat-square&logo=bunq&logoColor=white)](https://bunq.me/ahu)
 
 This repository provides a Docker image and entrypoint to run the censhare-Service-Client with a consistent, containerized setup. It supports dynamic configuration at runtime or pre-configuration during image build.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # censhare-Service-Client Docker Configuration
 
+> Production hardening and rendering experiments for censhare image tooling in containerized Service-Client workflows.
+
+[![Support via bunq](https://img.shields.io/badge/Support-bunq-00A1E0?style=flat-square&logo=bunq&logoColor=white)](https://bunq.me/ahu)
+
 This repository provides a Docker image and entrypoint to run the censhare-Service-Client with a consistent, containerized setup. It supports dynamic configuration at runtime or pre-configuration during image build.
 
 ## Overview
@@ -203,6 +207,10 @@ Delegates (built-in): bzlib cairo djvu fftw fontconfig fpx freetype gvc heic jbi
 ## Customization
 
 You can adjust the behavior in `entrypoint.py` and the Dockerfile to fit your needs. The entrypoint handles environment variables for flexible runtime configuration.
+
+## Support
+
+Voluntary support helps fund ongoing freelance maintenance of this repository. Support payments are appreciated but do not automatically create an entitlement to support, feature delivery, consulting, SLA, or invoice-based engagement.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add one project-specific header line at the top of `README.md`
- add a small bunq support button near the top
- add concise freelance-maintenance support wording with explicit no-entitlement language

## Tests
- not run (docs-only change)

## Risk
- low (README-only)

## Support wording preview
Voluntary support helps fund ongoing freelance maintenance of this repository. Support payments are appreciated but do not create an entitlement to support, feature delivery, consulting, SLA, or invoice-based engagement.
