### PR TITLE
docs: align README top heading with repo identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# censhare-Service-Client Docker Configuration
+# cs-image-tools
 
 > Production hardening and rendering experiments for censhare image tooling in containerized Service-Client workflows.
 


### PR DESCRIPTION
## Summary\n- update top README heading to the repository name ()\n- keep existing concise value proposition and badge layout\n\n## Why\nAligns README top section with the baseline headline convention.