### PR TITLE
ci: add Docker quality lint gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,33 +2,48 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main]
+  push:
+    branches: [main]
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
-  # -------------------------------------------------
-  # PR validation: build & test on amd64
-  # -------------------------------------------------
-  build-and-test-amd64:
-    name: Build and test (amd64, PR)
+  lint:
+    name: Dockerfile and shell lint
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Hadolint (Dockerfile)
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+      - name: ShellCheck (entrypoint)
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: .
+          additional_files: entrypoint.sh
+
+  build-and-test-amd64:
+    name: Build and test (amd64)
+    runs-on: ubuntu-latest
+    needs: lint
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          buildkitd-flags: --debug
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -36,18 +51,10 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Login to DockerHub (optional)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v2
-        with:
-          username: ahuservices
-          password: ${{ env.DOCKERHUB_TOKEN }}
+        uses: docker/setup-qemu-action@v3
 
       - name: Build Docker image for testing (amd64)
         run: |
-          # buildx builder is already set up by the action; just use it
           docker buildx build \
             --target test \
             --platform linux/amd64 \
@@ -56,28 +63,23 @@ jobs:
             .
 
       - name: Run tests (amd64)
-        run: |
-          docker run --rm cs-image-tools:${{ github.sha }}-amd64-test
+        run: docker run --rm cs-image-tools:${{ github.sha }}-amd64-test
 
-  # -------------------------------------------------
-  # Release: test once (amd64), then multi-arch build & push
-  # -------------------------------------------------
   release-multi-arch-build-and-push:
     name: Release multi-arch build and push
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    needs: build-and-test-amd64
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          buildkitd-flags: --debug
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -85,30 +87,16 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ahuservices
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and run tests (amd64, test stage)
-        run: |
-          # Build the test target for amd64 and load it locally
-          docker buildx build \
-            --target test \
-            --platform linux/amd64 \
-            --tag cs-image-tools:${{ github.sha }}-amd64-test \
-            --output type=docker \
-            .
-
-          # Run tests once before we build & push release images
-          docker run --rm cs-image-tools:${{ github.sha }}-amd64-test
-
       - name: Build and push multi-arch Docker image (amd64 + arm64)
         run: |
-          # Final multi-arch build & push for the release
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --tag ahuservices/cs-image-tools:latest \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
+          failure-threshold: error
 
-      - name: ShellCheck (entrypoint)
+      - name: ShellCheck (repository shell files)
         uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: .
-          additional_files: entrypoint.sh
 
   build-and-test-amd64:
     name: Build and test (amd64)


### PR DESCRIPTION
## Summary\n- add Hadolint gate for Dockerfile\n- add ShellCheck gate for shell scripts\n- keep build/test pipeline and modernize action versions\n\n## Why\nFor Docker-heavy repos, lint + build/test is the highest-value baseline without fake coverage requirements.