### PR TITLE
Add public artifact hygiene guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,25 @@ permissions:
   contents: read
 
 jobs:
+  public-artifact-hygiene:
+    name: Public artifact hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pre-commit
+        run: python3 -m pip install --user pre-commit
+
+      - name: Run public artifact guard
+        run: python3 -m pre_commit run public-artifact-hygiene --all-files
+
   lint:
     name: Dockerfile and shell lint
     runs-on: ubuntu-latest
+    needs: public-artifact-hygiene
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,33 +2,48 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main]
+  push:
+    branches: [main]
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
-  # -------------------------------------------------
-  # PR validation: build & test on amd64
-  # -------------------------------------------------
-  build-and-test-amd64:
-    name: Build and test (amd64, PR)
+  lint:
+    name: Dockerfile and shell lint
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Hadolint (Dockerfile)
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+      - name: ShellCheck (entrypoint)
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: .
+          additional_files: entrypoint.sh
+
+  build-and-test-amd64:
+    name: Build and test (amd64)
+    runs-on: ubuntu-latest
+    needs: lint
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          buildkitd-flags: --debug
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -36,18 +51,10 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Login to DockerHub (optional)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v2
-        with:
-          username: ahuservices
-          password: ${{ env.DOCKERHUB_TOKEN }}
+        uses: docker/setup-qemu-action@v3
 
       - name: Build Docker image for testing (amd64)
         run: |
-          # buildx builder is already set up by the action; just use it
           docker buildx build \
             --target test \
             --platform linux/amd64 \
@@ -56,28 +63,23 @@ jobs:
             .
 
       - name: Run tests (amd64)
-        run: |
-          docker run --rm cs-image-tools:${{ github.sha }}-amd64-test
+        run: docker run --rm cs-image-tools:${{ github.sha }}-amd64-test
 
-  # -------------------------------------------------
-  # Release: test once (amd64), then multi-arch build & push
-  # -------------------------------------------------
   release-multi-arch-build-and-push:
     name: Release multi-arch build and push
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    needs: build-and-test-amd64
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          buildkitd-flags: --debug
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -85,30 +87,16 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ahuservices
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and run tests (amd64, test stage)
-        run: |
-          # Build the test target for amd64 and load it locally
-          docker buildx build \
-            --target test \
-            --platform linux/amd64 \
-            --tag cs-image-tools:${{ github.sha }}-amd64-test \
-            --output type=docker \
-            .
-
-          # Run tests once before we build & push release images
-          docker run --rm cs-image-tools:${{ github.sha }}-amd64-test
-
       - name: Build and push multi-arch Docker image (amd64 + arm64)
         run: |
-          # Final multi-arch build & push for the release
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --tag ahuservices/cs-image-tools:latest \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
+          failure-threshold: error
 
-      - name: ShellCheck (entrypoint)
+      - name: ShellCheck (repository shell files)
         uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: .
-          additional_files: entrypoint.sh
 
   build-and-test-amd64:
     name: Build and test (amd64)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: public-artifact-hygiene
+        name: public-artifact-hygiene
+        entry: python3 scripts/public_artifact_guard.py
+        language: system
+        pass_filenames: true
+        files: ^(?:\.pre-commit-config\.yaml|README(?:\.[^/]+)?|CHANGELOG(?:\.[^/]+)?|SECURITY(?:\.[^/]+)?|CONTRIBUTING(?:\.[^/]+)?|docs/|.*\.(?:md|markdown|rst|txt|json|toml))$

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This repository provides a Docker image and entrypoint to run the censhare-Servi
 - Graceful shutdown handling for data integrity
 - Automatic Java runtime selection (Corretto 11/17/21) matching Service-Client version
 
+## Public artifact hygiene
+
+This repo includes a pre-commit/CI guard for public-facing text. See [docs/public-artifact-hygiene.md](docs/public-artifact-hygiene.md) for setup, failure interpretation, fixes, and reruns.
+
 ## Prerequisites
 
 - Docker installed: see https://docs.docker.com/get-docker/

--- a/docs/public-artifact-hygiene.md
+++ b/docs/public-artifact-hygiene.md
@@ -1,0 +1,49 @@
+# Public artifact hygiene guard
+
+This repository ships a local pre-commit hook and a CI check that scan public-facing text for accidental leakage before it is published.
+
+## What it checks
+
+- escaped newline sequences where real line breaks were intended
+- prompt / board / session metadata leakage
+- local or machine-specific paths
+- internal hostnames or private IPs
+- internal email identities
+- secret-like values and tokens
+
+## Local setup
+
+Install the hook once:
+
+```bash
+pre-commit install --install-hooks
+```
+
+Run it manually on the repo:
+
+```bash
+pre-commit run public-artifact-hygiene --all-files
+```
+
+## Before you publish text
+
+Use the same guard on a draft PR body, comment, commit message, or release note:
+
+```bash
+printf '%s' "$DRAFT_TEXT" | python3 scripts/public_artifact_guard.py - --stdin-label "draft text"
+```
+
+## How to read failures
+
+Each failure shows:
+
+- the source file or text source
+- the line number
+- the rule that matched
+- the offending line
+
+Fix the text, then rerun the same command.
+
+## CI behavior
+
+GitHub Actions runs the same hook on tracked public artifacts and scans pull request, push, and release text when that metadata is available.

--- a/scripts/public_artifact_guard.py
+++ b/scripts/public_artifact_guard.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Scan public-facing repo artifacts for accidental leakage.
+
+The guard is intentionally focused on publishable text artifacts such as
+README/docs files, GitHub workflow/config files, and other human-readable
+release material. It also inspects PR/release/commit text when running in
+GitHub Actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+TEXT_SUFFIXES = {
+    ".md",
+    ".markdown",
+    ".rst",
+    ".txt",
+    ".json",
+    ".toml",
+}
+SPECIAL_BASENAMES = {
+    ".pre-commit-config.yaml",
+    "README",
+    "README.md",
+    "README.rst",
+    "CHANGELOG",
+    "CHANGELOG.md",
+    "SECURITY",
+    "SECURITY.md",
+    "CONTRIBUTING",
+    "CONTRIBUTING.md",
+}
+
+SAFE_SECRET_HINTS = (
+    "example",
+    "placeholder",
+    "replace",
+    "replace-me",
+    "dummy",
+    "changeme",
+    "change-me",
+    "your-",
+    "your_",
+    "foobar",
+    "password",
+    "secret",
+    "token",
+)
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    pattern: re.Pattern[str]
+    message: str
+
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        "escaped-newline",
+        re.compile(r"\\n"),
+        "literal escaped \\n appears in public text; use real line breaks instead",
+    ),
+    Rule(
+        "prompt-board-leak",
+        re.compile(
+            r"(?i)\b(?:"
+            r"openclaw|planka|AGENTS\.md|HEARTBEAT\.md|"
+            r"boardId|cardId|sessionId|notifyChannel|notifyTarget|"
+            r"notifyReplyTo|notifyThreadId|reply_to|reply-to|subagent|heartbeat"
+            r")\b"
+        ),
+        "prompt/board/session metadata should not appear in public artifacts",
+    ),
+    Rule(
+        "local-path",
+        re.compile(
+            r"(?<!\w)(?:"
+            r"/home/[^\s'\"`]+|"
+            r"/Users/[^\s'\"`]+|"
+            r"/tmp/[^\s'\"`]+|"
+            r"/private/var/[^\s'\"`]+|"
+            r"/var/folders/[^\s'\"`]+|"
+            r"~/(?:[^\s'\"`]+)?|"
+            r"C:\\[^\s'\"`]+|"
+            r"\\\\[^\s'\"`]+"
+            r")"
+        ),
+        "local or machine-specific paths should be replaced with neutral placeholders",
+    ),
+    Rule(
+        "internal-host",
+        re.compile(
+            r"(?i)\b(?:"
+            r"localhost|127\.0\.0\.1|10\.(?:\d{1,3}\.){2}\d{1,3}|"
+            r"192\.168\.\d{1,3}\.\d{1,3}|"
+            r"172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|"
+            r"(?:[A-Za-z0-9-]+\.)+(?:corp|internal|lan|local)"
+            r")\b"
+        ),
+        "internal hostnames/IPs should not be published in public artifacts",
+    ),
+    Rule(
+        "internal-email",
+        re.compile(r"(?i)\b[\w.+-]+@(?:ahu\.services|openclaw\.[\w.-]+)\b"),
+        "internal email identities should not be published in public artifacts",
+    ),
+    Rule(
+        "secret-like",
+        re.compile(
+            r"(?i)\b(?:"
+            r"ghp_[A-Za-z0-9]{20,}|"
+            r"github_pat_[A-Za-z0-9_]{20,}|"
+            r"AKIA[0-9A-Z]{16}|"
+            r"(?:xox[baprs]-[A-Za-z0-9-]{10,})|"
+            r"(?:sk-[A-Za-z0-9]{16,})|"
+            r"(?:password|secret|token|api[_-]?key|client_secret|private_key)\b\s*[:=]\s*[^\s'\"`]{8,}"
+            r")",
+        ),
+        "secret-like values should be removed or replaced with placeholders",
+    ),
+)
+
+
+@dataclass
+class Finding:
+    source: str
+    line_no: int
+    rule_id: str
+    message: str
+    excerpt: str
+
+
+def is_public_artifact_path(path: str) -> bool:
+    candidate = Path(path)
+    name = candidate.name
+    if name in SPECIAL_BASENAMES:
+        return True
+    if path.startswith("docs/"):
+        return True
+    if name.startswith("README") or name.startswith("CHANGELOG") or name.startswith("SECURITY") or name.startswith("CONTRIBUTING"):
+        return True
+    if candidate.suffix.lower() in TEXT_SUFFIXES:
+        return True
+    return False
+
+
+def read_text(path: Path) -> str | None:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    if b"\x00" in data:
+        return None
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("utf-8", errors="replace")
+
+
+def scan_text(text: str, source: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        value_part = line
+        if ":" in line or "=" in line:
+            for separator in (":", "="):
+                if separator in line:
+                    value_part = line.split(separator, 1)[1].strip()
+                    break
+        value_lowered = value_part.lower()
+        for rule in RULES:
+            match = rule.pattern.search(line)
+            if not match:
+                continue
+            if rule.rule_id == "secret-like" and any(hint in value_lowered for hint in SAFE_SECRET_HINTS):
+                continue
+            findings.append(
+                Finding(
+                    source=source,
+                    line_no=idx,
+                    rule_id=rule.rule_id,
+                    message=rule.message,
+                    excerpt=line.strip(),
+                )
+            )
+    return findings
+
+
+def git_output(args: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout
+
+
+def scan_files(paths: Iterable[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for raw_path in paths:
+        if raw_path == "-":
+            continue
+        if not is_public_artifact_path(raw_path):
+            continue
+        text = read_text(Path(raw_path))
+        if text is None:
+            continue
+        findings.extend(scan_text(text, raw_path))
+    return findings
+
+
+def github_metadata_texts() -> list[tuple[str, str]]:
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        return []
+    try:
+        with open(event_path, "r", encoding="utf-8") as handle:
+            event = json.load(handle)
+    except OSError:
+        return []
+    except json.JSONDecodeError:
+        return []
+
+    texts: list[tuple[str, str]] = []
+    event_name = os.getenv("GITHUB_EVENT_NAME", "")
+
+    if event_name == "pull_request":
+        pr = event.get("pull_request") or {}
+        title = pr.get("title")
+        body = pr.get("body")
+        if title:
+            texts.append(("github.pull_request.title", str(title)))
+        if body:
+            texts.append(("github.pull_request.body", str(body)))
+        base_sha = (pr.get("base") or {}).get("sha")
+        head_sha = (pr.get("head") or {}).get("sha")
+        if base_sha and head_sha:
+            commit_text = git_output(["log", "--format=%B", f"{base_sha}..{head_sha}"])
+            if commit_text:
+                texts.append(("github.pull_request.commits", commit_text))
+            else:
+                commit_text = git_output(["log", "-n", "20", "--format=%B", "HEAD"])
+                if commit_text:
+                    texts.append(("github.pull_request.commits", commit_text))
+    elif event_name == "push":
+        for commit in event.get("commits") or []:
+            message = commit.get("message")
+            if message:
+                texts.append((f"github.push.commit.{commit.get('id', 'unknown')[:7]}", str(message)))
+    elif event_name == "release":
+        release = event.get("release") or {}
+        name = release.get("name")
+        body = release.get("body")
+        tag = release.get("tag_name")
+        if name:
+            texts.append(("github.release.name", str(name)))
+        if tag:
+            texts.append(("github.release.tag", str(tag)))
+        if body:
+            texts.append(("github.release.body", str(body)))
+
+    return texts
+
+
+def scan_github_metadata() -> list[Finding]:
+    findings: list[Finding] = []
+    for source, text in github_metadata_texts():
+        findings.extend(scan_text(text, source))
+    return findings
+
+
+def staged_files() -> list[str]:
+    output = git_output(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    return [line for line in (output or "").splitlines() if line]
+
+
+def tracked_files() -> list[str]:
+    output = git_output(["ls-files"])
+    return [line for line in (output or "").splitlines() if line]
+
+
+def emit(findings: list[Finding]) -> int:
+    if not findings:
+        print("public-artifact-guard: ok")
+        return 0
+
+    print(f"public-artifact-guard: {len(findings)} issue(s) found", file=sys.stderr)
+    for finding in findings:
+        print(
+            f"{finding.source}:{finding.line_no}: [{finding.rule_id}] {finding.message}\n"
+            f"  {finding.excerpt}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Files to scan. Use '-' to scan stdin.")
+    parser.add_argument(
+        "--all-files",
+        action="store_true",
+        help="Scan all tracked files in the repository.",
+    )
+    parser.add_argument(
+        "--stdin-label",
+        default="stdin",
+        help="Label to use when scanning data from stdin.",
+    )
+    args = parser.parse_args()
+
+    findings: list[Finding] = []
+
+    if args.all_files:
+        findings.extend(scan_files(tracked_files()))
+    elif args.paths:
+        if "-" in args.paths:
+            stdin_text = sys.stdin.read()
+            findings.extend(scan_text(stdin_text, args.stdin_label))
+        findings.extend(scan_files([path for path in args.paths if path != "-"]))
+    else:
+        findings.extend(scan_files(staged_files()))
+
+    findings.extend(scan_github_metadata())
+    return emit(findings)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_public_artifact_guard.py
+++ b/tests/test_public_artifact_guard.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "public_artifact_guard.py"
+spec = importlib.util.spec_from_file_location("public_artifact_guard", MODULE_PATH)
+assert spec and spec.loader
+public_artifact_guard = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = public_artifact_guard
+spec.loader.exec_module(public_artifact_guard)
+
+
+def rule_ids(findings):
+    return [finding.rule_id for finding in findings]
+
+
+def test_scan_text_flags_public_artifact_leaks():
+    findings = public_artifact_guard.scan_text(
+        "boardId=123\npath=/home/alice/.ssh/id_rsa\nvalue=foo\\nbar",
+        "draft.txt",
+    )
+
+    assert "prompt-board-leak" in rule_ids(findings)
+    assert "local-path" in rule_ids(findings)
+    assert "escaped-newline" in rule_ids(findings)
+
+
+def test_scan_text_allows_placeholder_values():
+    findings = public_artifact_guard.scan_text(
+        "SVC_HOST=host.example.com\nsecret=foobar\npassword=password",
+        "README.md",
+    )
+
+    assert findings == []
+
+
+def test_scan_text_flags_secret_like_token():
+    findings = public_artifact_guard.scan_text(
+        "token=ghp_123456789012345678901234567890123456",
+        "release-note.md",
+    )
+
+    assert "secret-like" in rule_ids(findings)


### PR DESCRIPTION
Add a repo-local pre-commit hook and CI check for public-facing artifact hygiene.

What changed:
- adds a local guard script and pre-commit config
- scans docs/public text for escaped newlines, local paths, internal metadata, and secret-like values
- documents how to run, interpret, fix, and rerun the check
- wires the same guard into CI

Gates:
- pre-commit run public-artifact-hygiene --all-files
- PYTHONPATH=. .venv/bin/pytest tests/test_entrypoint.py tests/test_health_check.py tests/test_public_artifact_guard.py

External blocker:
- Docker daemon access is not available from this environment (permission denied on /var/run/docker.sock), so the container build/test gate could not be run here.