### PR TITLE
Harden entrypoint and bump bundled tool versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install ca-certificates
 
 ### Build Ghostscript
 FROM debian-builder AS ghostscript-builder
-ARG GHOSTSCRIPT_VERSION=10.07.0
+ARG GHOSTSCRIPT_VERSION=10.07.1
 
 # Download and build Ghostscript
 WORKDIR /tmp
@@ -48,7 +48,7 @@ RUN apt-get update && apt-get install -y cmake ninja-build clang libjpeg-dev \
 
 ### Build ImageMagick
 FROM debian-builder AS im-builder
-ARG IMAGEMAGICK_VERSION=7.1.2-18
+ARG IMAGEMAGICK_VERSION=7.1.2-24
 
 # Download ImageMagick
 WORKDIR /tmp
@@ -79,7 +79,7 @@ COPY imagemagick-policy.xml /IM-build/usr/local/etc/ImageMagick-7/policy.xml
 
 ### Build ffmpeg
 FROM debian-builder AS ffmpeg-builder
-ARG FFMPEG_VERSION=8.1
+ARG FFMPEG_VERSION=8.1.1
 
 # Download and build ffmpeg
 WORKDIR /tmp
@@ -93,7 +93,7 @@ RUN wget https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz \
 
 ### Build ExifTool
 FROM debian-builder AS exif-builder
-ARG EXIF_VERSION=13.50
+ARG EXIF_VERSION=13.55
 
 # Download and build ExifTool
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ When you pass `VERSION` during image build, the Dockerfile fetches and installs 
 
 | Tool         | Version   |
 |--------------|-----------|
-| ImageMagick  | 7.1.2-18  |
-| Ghostscript  | 10.07.0   |
-| ExifTool     | 13.50     |
-| FFmpeg       | 8.1       |
+| ImageMagick  | 7.1.2-24  |
+| Ghostscript  | 10.07.1   |
+| ExifTool     | 13.55     |
+| FFmpeg       | 8.1.1     |
 | pngquant     | 3.0.3     |
 | wkhtmltoimage| 0.12.6.1-3|
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -54,9 +54,11 @@ def str_to_bool(value):
     Convert a string to a boolean.
     Returns True for 'true', '1', 't', 'y', 'yes' (case insensitive).
     Returns False for 'false', '0', 'f', 'n', 'no' (case insensitive).
-    Defaults to False for any other value.
+    Defaults to False for any other value (including None).
     """
-    return value.lower() in ["true", "1", "t", "y", "yes"]
+    if not value:
+        return False
+    return value.strip().lower() in {"true", "1", "t", "y", "yes"}
 
 
 def _read_first_line(path):
@@ -297,40 +299,43 @@ def download_unpack(url, output_path):
     Raises:
     SystemExit: If the download fails or the HTTP status is not 200.
     """
-    response = requests.get(url, stream=True)
-    if response.status_code == 200:
-        hashers = {
-            "md5": hashlib.md5(),
-            "sha256": hashlib.sha256(),
-        }
-        with open(output_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-                for hasher in hashers.values():
-                    hasher.update(chunk)
-        print("Download complete.")
-        print("Archive checksums:")
-        for name, hasher in hashers.items():
-            print(f"  {name.upper()}: {hasher.hexdigest()}")
-        print("Unpacking...")
-        with tarfile.open(output_path) as tar:
-            try:
-                tar.extractall(path="/opt/corpus/", filter="data")
-            except TypeError:
-                # Fallback for older Python versions without the filter argument.
-                tar.extractall(path="/opt/corpus/")
-        print("Unpacking complete.")
-        subprocess.run(["chown", "-R", "corpus:corpus", "/opt/corpus/"], check=True)
-        detected_version = _determine_serviceclient_version()
-        if detected_version:
-            print(f"Installed service client version: {detected_version}")
-        else:
-            print(
-                "Warning: Could not determine installed service client version from serviceclient.sh."
-            )
-    else:
-        print("Failed to download the file.")
+    # (connect timeout, read timeout) so a stalled connection fails fast instead
+    # of hanging the container start indefinitely.
+    response = requests.get(url, stream=True, timeout=(10, 60))
+    if response.status_code != 200:
+        print(f"Failed to download the file (HTTP {response.status_code}).")
         sys.exit(1)
+
+    hashers = {
+        # usedforsecurity=False: MD5 here is only an integrity/identity checksum.
+        "md5": hashlib.md5(usedforsecurity=False),
+        "sha256": hashlib.sha256(),
+    }
+    with open(output_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+            for hasher in hashers.values():
+                hasher.update(chunk)
+    print("Download complete.")
+    print("Archive checksums:")
+    for name, hasher in hashers.items():
+        print(f"  {name.upper()}: {hasher.hexdigest()}")
+    print("Unpacking...")
+    with tarfile.open(output_path) as tar:
+        try:
+            tar.extractall(path="/opt/corpus/", filter="data")
+        except TypeError:
+            # Fallback for older Python versions without the filter argument.
+            tar.extractall(path="/opt/corpus/")
+    print("Unpacking complete.")
+    subprocess.run(["chown", "-R", "corpus:corpus", "/opt/corpus/"], check=True)
+    detected_version = _determine_serviceclient_version()
+    if detected_version:
+        print(f"Installed service client version: {detected_version}")
+    else:
+        print(
+            "Warning: Could not determine installed service client version from serviceclient.sh."
+        )
 
 
 def select_jdk_major(client_version):
@@ -520,10 +525,12 @@ def configure_xml(
     tree = ET.parse(path)
     root = tree.getroot()
 
-    # Update connection settings (force port-range to keep listeners in a fixed window)
-    connection = root.find('.//connection[@type="port-range"]') or root.find(
-        './/connection[@type="standard"]'
-    )
+    # Update connection settings (force port-range to keep listeners in a fixed window).
+    # Use explicit "is not None" checks: attribute-only Elements are falsy, so an
+    # "x or y" fallback would silently skip a present-but-childless <connection>.
+    connection = root.find('.//connection[@type="port-range"]')
+    if connection is None:
+        connection = root.find('.//connection[@type="standard"]')
     if connection is not None:
         connection.set("type", "port-range")
         connection.set("client-map-host-from", client_map_host_from)
@@ -537,19 +544,19 @@ def configure_xml(
 
     # Update facilities instances
     facilities = root.find(".//facilities")
-    facilities.attrib["instances"] = svc_instances
+    if facilities is None:
+        print("Warning: No <facilities> element found in serviceclient preferences.")
+    else:
+        facilities.attrib["instances"] = svc_instances
 
-    # Optional: Override timeouts via environment variables
-    for facility in facilities.findall(".//facility"):
-        key = facility.attrib["key"]
-        timeout_env_var = os.getenv(f"{key.upper()}_TIMEOUT")
-        if timeout_env_var:
-            facility.set("timeout", timeout_env_var)
-
-    # Update paths and other settings for each facility
-    for facility in facilities.findall(".//facility"):
-        key = facility.attrib["key"]
-        update_facility_paths(facility, key, office_url)
+        # Apply optional per-facility timeout overrides and resolve tool paths in
+        # a single pass over the facilities.
+        for facility in facilities.findall(".//facility"):
+            key = facility.attrib["key"]
+            timeout_env_var = os.getenv(f"{key.upper()}_TIMEOUT")
+            if timeout_env_var:
+                facility.set("timeout", timeout_env_var)
+            update_facility_paths(facility, key, office_url)
 
     update_volumes_configuration(f"{base_dir}/config/hosts.xml")
 
@@ -557,20 +564,24 @@ def configure_xml(
     print("XML configuration updated.")
 
 
+# Maps each facility key to its placeholder/binary path pairs in the preferences XML.
+FACILITY_PATH_MAP = {
+    "imagemagick": (
+        "@@CONVERT@@",
+        "/usr/local/bin/magick",
+        "@@COMPOSITE@@",
+        "/usr/local/bin/composite",
+    ),
+    "exiftool": ("@@EXIFTOOL@@", "/usr/local/bin/exiftool"),
+    "ghostscript": ("@@GS@@", "/usr/local/bin/gs"),
+    "wkhtmltoimage": ("@@HTML2IMG@@", "/usr/local/bin/wkhtmltoimage"),
+    "pngquant": ("@@PNGQUANT@@", "/usr/local/bin/pngquant"),
+    "ffmpeg": ("@@FFMPEG-PATH@@", "/usr/local/bin/ffmpeg"),
+}
+
+
 def get_path_map():
-    return {
-        "imagemagick": (
-            "@@CONVERT@@",
-            "/usr/local/bin/magick",
-            "@@COMPOSITE@@",
-            "/usr/local/bin/composite",
-        ),
-        "exiftool": ("@@EXIFTOOL@@", "/usr/local/bin/exiftool"),
-        "ghostscript": ("@@GS@@", "/usr/local/bin/gs"),
-        "wkhtmltoimage": ("@@HTML2IMG@@", "/usr/local/bin/wkhtmltoimage"),
-        "pngquant": ("@@PNGQUANT@@", "/usr/local/bin/pngquant"),
-        "ffmpeg": ("@@FFMPEG-PATH@@", "/usr/local/bin/ffmpeg"),
-    }
+    return FACILITY_PATH_MAP
 
 
 def update_facility_paths(facility, key, office_url):
@@ -582,11 +593,9 @@ def update_facility_paths(facility, key, office_url):
     facility (ET.Element): XML element that contains facility configuration.
     key (str): Facility key to determine which paths to update.
     """
-    path_map = get_path_map()
-
     # Update paths based on facility key
-    if key in path_map:
-        paths = path_map[key]
+    if key in FACILITY_PATH_MAP:
+        paths = FACILITY_PATH_MAP[key]
         target_paths = []
         for i in range(0, len(paths), 2):
             path_element = facility.find(f".//path[@key='{paths[i]}']")

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -35,7 +35,7 @@ def test_download_unpack_logs_checksums(monkeypatch, tmp_path, capsys):
             yield chunk
 
     monkeypatch.setattr(
-        entrypoint.requests, "get", lambda url, stream=True: DummyResponse()
+        entrypoint.requests, "get", lambda url, **kwargs: DummyResponse()
     )
 
     # Stub tarfile extraction to materialize a serviceclient script
@@ -143,6 +143,38 @@ def test_configure_xml_defaults_to_constant_port(monkeypatch, tmp_path):
         entrypoint.os.getenv("SERVICECLIENT_JAVA_OPTIONS")
         == "-Djava.rmi.server.hostname=10.0.0.9"
     )
+
+
+def test_configure_xml_updates_existing_port_range_connection(monkeypatch, tmp_path):
+    # A pre-existing, attribute-only <connection type="port-range"/> is falsy as an
+    # ElementTree element; ensure it is still located via an explicit None check and
+    # not silently skipped in favour of a missing "standard" connection.
+    prefs_dir = tmp_path / "config" / ".hosts" / "host4"
+    prefs_dir.mkdir(parents=True, exist_ok=True)
+    prefs_path = prefs_dir / "serviceclient-preferences-user4.xml"
+    prefs_path.write_text(
+        """<root>
+  <connection type="port-range" server-port-range-from="1" server-port-range-to="1"/>
+  <facilities instances="1">
+    <facility key="imagemagick"/>
+  </facilities>
+</root>
+"""
+    )
+    (tmp_path / "config" / "hosts.xml").write_text("<root/>")
+
+    monkeypatch.setenv("SERVICECLIENT_RMI_PORT", "40000")
+    monkeypatch.delenv("SERVICECLIENT_RMI_PORT_TO", raising=False)
+    monkeypatch.delenv("SERVICECLIENT_CALLBACK_HOST", raising=False)
+    monkeypatch.delenv("SERVICECLIENT_JAVA_OPTIONS", raising=False)
+    monkeypatch.setattr(entrypoint, "detect_rmi_host_ip", lambda: "10.0.0.20")
+
+    entrypoint.configure_xml("host4", "user4", base_dir=str(tmp_path))
+
+    connection = ET.parse(prefs_path).getroot().find(".//connection")
+    assert connection.get("type") == "port-range"
+    assert connection.get("server-port-range-from") == "40000"
+    assert connection.get("server-port-range-to") == "40000"
 
 
 def test_configure_xml_respects_explicit_client_mapping(monkeypatch, tmp_path):

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -31,7 +31,7 @@ def test_user_corpus_can_execute_commands():
 
 def test_ghostscript_installed_and_version():
     """Test that Ghostscript is installed, executable, and the version is correct."""
-    expected_version = "10.07.0"
+    expected_version = "10.07.1"
     try:
         # Check if 'gs' command is available and get version
         result = subprocess.run(
@@ -62,7 +62,7 @@ def test_ghostscript_installed_and_version():
 
 def test_imagemagick_installed_and_version():
     """Test that ImageMagick is installed, executable, and the version is correct."""
-    expected_version = "7.1.2-18"
+    expected_version = "7.1.2-24"
     expected_features = "Features: Cipher DPC HDRI Modules OpenMP(4.5)"
     expected_delegagtes = "Delegates (built-in): bzlib cairo djvu fftw fontconfig fpx freetype gvc heic jbig jng jp2 jpeg jxl lcms ltdl lzma openexr pangocairo png raqm raw rsvg tiff uhdr webp wmf xml zip zlib zstd"
 
@@ -109,7 +109,7 @@ def test_imagemagick_installed_and_version():
 
 def test_exiftool_installed_and_version():
     """Test that ExifTool is installed, executable, and the version is correct."""
-    expected_version = "13.50"
+    expected_version = "13.55"
     try:
         # Check if 'exiftool' command is available and get version
         result = subprocess.run(
@@ -147,7 +147,7 @@ def test_exiftool_installed_and_version():
 
 def test_ffmpeg_installed_and_version():
     """Test that ffmpeg is installed, executable, and the version is correct."""
-    expected_version = "8.1"
+    expected_version = "8.1.1"
     try:
         # Check if 'ffmpeg' command is available and get version
         result = subprocess.run(


### PR DESCRIPTION
## Summary

Code analysis of the project surfaced a few latent robustness issues in `entrypoint.py` plus a batch of out-of-date bundled tool versions. This PR fixes both, in two self-contained commits.

### 1. Entrypoint hardening (`fix: harden entrypoint XML handling and downloads`)

- **`configure_xml` connection selection bug** — `root.find('.//connection[@type="port-range"]') or root.find('.//connection[@type="standard"]')` relied on element truthiness. Attribute-only ElementTree elements are **falsy**, so a present-but-childless `port-range` connection was silently skipped, dropping the RMI port-range configuration. Switched to explicit `is not None` checks. Confirmed with a new regression test.
- **`configure_xml` `<facilities>` guard** — added a `None` guard (previously an `AttributeError` risk, unlike the `connection` element) and merged the two passes over the facilities into a single loop.
- **`download_unpack` network timeout** — added connect/read timeouts so a stalled Service-Client download fails fast instead of hanging container startup; check the HTTP status before processing and mark the MD5 integrity checksum `usedforsecurity=False`.
- **`str_to_bool`** — tolerates `None` and surrounding whitespace.
- Promoted the per-call facility path map to a module-level constant.

### 2. Tool version bumps (`build: bump bundled tool versions to latest releases`)

| Tool | Old | New |
|------|-----|-----|
| ImageMagick | 7.1.2-18 | 7.1.2-24 |
| Ghostscript | 10.07.0 | 10.07.1 |
| ExifTool | 13.50 | 13.55 (production) |
| FFmpeg | 8.1 | 8.1.1 |

`pngquant` (3.0.3) and `wkhtmltoimage` (0.12.6.1-3) are already at their latest upstream releases. Dockerfile build args, the README tool table, and the installation test expectations are updated in lockstep.

## Testing

- `ruff check` / `ruff format --check`: clean
- `pytest tests/test_entrypoint.py tests/test_health_check.py`: 15 passed (14 existing + 1 new regression test)
- The tool version bumps are validated by the `build-and-test-amd64` CI job, which compiles each tool and runs `tests/test_installation.py` against the resulting image.

https://claude.ai/code/session_01UXS2APE8WgSqQHFqAPCZLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXS2APE8WgSqQHFqAPCZLM)_