### PR TITLE
docs: add CI badge, unify support badge, add governance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS
+
+This repository accepts AI-assisted contributions.
+
+## Guardrails
+- Keep changes small and reviewable.
+- Be careful with the entrypoint and Dockerfile; they control runtime configuration and credential handling.
+- Do not commit secrets, repository credentials, or service credentials.
+- Run `pre-commit run --all-files` (ruff, hadolint, shellcheck, yamllint) before publishing PR text, commits, or docs.
+
+## Required Human Checks
+- Review every AI-generated change before merge.
+- Validate networking/RMI callback logic and ImageMagick policy handling.
+- Ensure docs (env vars, tool versions, Java matrix) match the implementation.
+
+## Attribution
+A concise note such as "AI-assisted" in the PR description is recommended for transparency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thanks for contributing to cs-image-tools.
+
+## Requirements
+- Docker
+- Python 3.x (for the entrypoint and local checks)
+- `pre-commit`
+
+## Development Setup
+```bash
+pip install pre-commit
+pre-commit install --install-hooks
+pre-commit run --all-files
+docker build -t cs-image-tools:dev .
+```
+
+The `hadolint` hook runs in a container. Without a local Docker daemon, skip it:
+
+```bash
+SKIP=hadolint-docker pre-commit run --all-files
+```
+
+## Branch and Commit Guidelines
+- Create a feature branch from `main`.
+- Use Conventional Commits, e.g.:
+  - `feat: add ICC profile auto-copy`
+  - `fix: correct RMI callback host detection`
+  - `docs: document VOLUMES_INFO usage`
+
+## Pull Request Checklist
+- Keep changes focused and minimal.
+- Update docs (env vars, tool versions) when behavior changes.
+- Run `pre-commit run --all-files` before opening a PR.
+- Ensure the image builds and CI is green.
+
+## Security and Secrets
+- Never commit repository credentials (`REPO_USER`/`REPO_PASS`), service credentials, or ICC/licensing material.
+- For vulnerabilities, follow `SECURITY.md`.
+
+## Review Policy
+- All PRs require human review before merge.
+- AI-assisted changes are welcome, but maintainers are responsible for final correctness.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ The `hadolint` hook runs in a container. Without a local Docker daemon, skip it:
 SKIP=hadolint-docker pre-commit run --all-files
 ```
 
+## Governance
+
+- Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Security policy: [SECURITY.md](SECURITY.md)
+- AI-agent guide: [AGENTS.md](AGENTS.md)
+- License: [LICENSE](LICENSE)
+
 ## Support
 
 If this Docker image is useful to you, you can [support its ongoing maintenance via bunq](https://bunq.me/ahuservices?description=cs-image-tools-maintenance-support). Support is voluntary and appreciated, but does not create any entitlement to support, features, consulting, an SLA, or invoice-based work.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 > Production hardening and rendering experiments for censhare image tooling in containerized Service-Client workflows.
 
+[![CI](https://github.com/ahu-services/cs-image-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/ahu-services/cs-image-tools/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/Container-Docker-2496ED?logo=docker&logoColor=white)](https://docs.docker.com/)
 [![Java](https://img.shields.io/badge/Java-11%2F17%2F21-007396?logo=openjdk&logoColor=white)](https://openjdk.org/)
 [![License](https://img.shields.io/github/license/ahu-services/cs-image-tools)](LICENSE)
 
-[![Support via bunq](https://img.shields.io/badge/Support-bunq-00A1E0?style=flat-square&logo=bunq&logoColor=white)](https://bunq.me/ahu)
+[![Support via bunq](https://img.shields.io/badge/Support-bunq-00A1E0?style=flat-square&logo=bunq&logoColor=white)](https://bunq.me/ahuservices?description=cs-image-tools-maintenance-support)
 
 This repository provides a Docker image and entrypoint to run the censhare-Service-Client with a consistent, containerized setup. It supports dynamic configuration at runtime or pre-configuration during image build.
 
@@ -230,7 +231,7 @@ SKIP=hadolint-docker pre-commit run --all-files
 
 ## Support
 
-Voluntary support helps fund ongoing freelance maintenance of this repository. Support payments are appreciated but do not automatically create an entitlement to support, feature delivery, consulting, SLA, or invoice-based engagement.
+If this Docker image is useful to you, you can [support its ongoing maintenance via bunq](https://bunq.me/ahuservices?description=cs-image-tools-maintenance-support). Support is voluntary and appreciated, but does not create any entitlement to support, features, consulting, an SLA, or invoice-based work.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ The `main` branch is the only actively supported line at the moment.
 ## Reporting a Vulnerability
 Please do not open public issues for security vulnerabilities.
 
-Report privately to the maintainer and include:
+Report privately by email to security@ahu.services and include:
 - affected component (Dockerfile, entrypoint, bundled tool)
 - impact and attack scenario
 - reproduction steps

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+The `main` branch is the only actively supported line at the moment.
+
+## Reporting a Vulnerability
+Please do not open public issues for security vulnerabilities.
+
+Report privately to the maintainer and include:
+- affected component (Dockerfile, entrypoint, bundled tool)
+- impact and attack scenario
+- reproduction steps
+- suggested mitigation if available
+
+You will receive an acknowledgement as soon as possible, and we will coordinate remediation and disclosure timing.
+
+## Hardening Notes
+- Never bake repository or service credentials into images or commit them to the repo.
+- Prefer passing secrets at runtime via environment variables or a secrets manager, not build args, for published images.
+- Run the container behind appropriate network controls; host networking exposes RMI callback ports.
+- Keep the base image and bundled media tools (ImageMagick, FFmpeg, Ghostscript, etc.) up to date.


### PR DESCRIPTION
Part of a cross-repo README/governance standardization.

## Changes
- Add the missing CI badge.
- Unify the bunq support badge/link (`bunq.me/ahuservices?description=cs-image-tools-maintenance-support`) and tighten the Support section.
- Add `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md` and a Governance section linking them.

No code changes.

https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb)_