### PR TITLE
ci: add SonarQube Cloud analysis (Python + Dockerfile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,11 @@ jobs:
           python-version: '3.11'
 
       - name: Install test dependencies
-        run: pip install pytest pytest-cov
+        run: pip install pytest pytest-cov requests
 
       - name: Unit tests with coverage
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: pytest tests/test_health_check.py tests/test_entrypoint.py --cov=. --cov-report=xml
 
       - name: SonarQube Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,34 @@ jobs:
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
 
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    needs: lint
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: pip install pytest pytest-cov
+
+      - name: Unit tests with coverage
+        run: pytest tests/test_health_check.py tests/test_entrypoint.py --cov=. --cov-report=xml
+
+      - name: SonarQube Scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
+
   build-and-test-amd64:
     name: Build and test (amd64)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 > Production hardening and rendering experiments for censhare image tooling in containerized Service-Client workflows.
 
 [![CI](https://github.com/ahu-services/cs-image-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/ahu-services/cs-image-tools/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ahu-services_cs-image-tools&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ahu-services_cs-image-tools)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ahu-services_cs-image-tools&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ahu-services_cs-image-tools)
 [![Docker](https://img.shields.io/badge/Container-Docker-2496ED?logo=docker&logoColor=white)](https://docs.docker.com/)
 [![Java](https://img.shields.io/badge/Java-11%2F17%2F21-007396?logo=openjdk&logoColor=white)](https://openjdk.org/)
 [![License](https://img.shields.io/github/license/ahu-services/cs-image-tools)](LICENSE)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=ahu-services_cs-image-tools
+sonar.organization=ahu-services
+
+sonar.sources=entrypoint.py,health_check.py,Dockerfile
+sonar.tests=tests
+
+sonar.python.version=3.11
+sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
## Summary

Adds SonarQube Cloud static analysis + quality gate. Analyzes the Python entrypoint/health-check scripts and the Dockerfile (IaC), with coverage from the host-runnable unit tests.

## Changes

- **`sonar-project.properties`** — project key `ahu-services_cs-image-tools`, org `ahu-services`. Sources: `entrypoint.py`, `health_check.py`, `Dockerfile`; tests in `tests/`; coverage from `coverage.xml`.
- **CI** — new `sonarqube` job runs the two host-runnable unit test files (`test_health_check.py`, `test_entrypoint.py`) with `pytest --cov`, then `SonarSource/sonarqube-scan-action@v8.1.0`. The Docker-bound `test_installation.py` stays in the Docker `test` stage as before. Guarded by `if: env.SONAR_TOKEN != ''` → **green/skipped until the secret exists**.
- **README** — added Quality Gate + Coverage badges.

## Notes

- The installation tests require the built container (ImageMagick et al.) and are intentionally **not** run on the host; only the pure-Python logic tests feed coverage.

## Required setup (you)

1. Create/import the project **`ahu-services_cs-image-tools`** in SonarQube Cloud org **`ahu-services`**.
2. Add repo Actions secret **`SONAR_TOKEN`**.
3. (Recommended) Disable SonarCloud "Automatic Analysis" so the CI-based scan is used.

Verified locally: `pytest test_health_check.py test_entrypoint.py --cov=. --cov-report=xml` → 14 passed, `coverage.xml` covers both modules.

https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb)_